### PR TITLE
Exit qr handling

### DIFF
--- a/src/models/handlers/EstablishmentHandler.js
+++ b/src/models/handlers/EstablishmentHandler.js
@@ -35,7 +35,7 @@ module.exports = function EstablishmentHandler() {
         _id: new mongoose.Types.ObjectId(),
         name: _space.name,
         m2: _space.m2,
-        exitQR: _space.exitQR,
+        hasExit: _space.hasExit,
         openPlace: _space.openPlace,
         establishmentId: establishmentData._id
       };
@@ -61,7 +61,7 @@ module.exports = function EstablishmentHandler() {
     let PDFInfo = [];
     for (const space_id of establishment.spaces) {
       let current_space = await SpaceHandler().findSpace(space_id);
-      if (current_space.exitQR) {
+      if (current_space.hasExit) {
         PDFInfo.push([`${current_space.name} Entrada`, space_id.toString()]);
         PDFInfo.push([`${current_space.name} Salida`, `${space_id.toString()}_exit`]);
       } else {

--- a/src/models/schemas/Space.js
+++ b/src/models/schemas/Space.js
@@ -9,7 +9,7 @@ let spaceSchema = mongoose.Schema({
     type: Number,
     required: true
   },
-  exitQR: {
+  hasExit: {
     type: Boolean,
     required: true
   },

--- a/test/integration/app.int.test.js
+++ b/test/integration/app.int.test.js
@@ -17,13 +17,13 @@ let country = 'Argentina';
 let spaces1 = [
     {
       name: "Primer piso",
-      exitQR: true,
+      hasExit: true,
       m2: "1000",
       openPlace: false
     },
     {
       name: "Terraza",
-      exitQR: false,
+      hasExit: false,
       m2: "400",
       openPlace: true
     }
@@ -36,7 +36,7 @@ let address2 = 'Cabildo 2020';
 let spaces2 = [
     {
       name: "Planta baja",
-      exitQR: false,
+      hasExit: false,
       m2: "3000",
       openPlace: false
     }


### PR DESCRIPTION
Si el parámetro exitQR es true, entonces genera dos QRs:
1. **Entrada**: Nombre dado por el establecimiento para ese lugar + " Entrada", y siendo el QR el id que guarda mongo para ese espacio
2. **Salida**: Nombre dado por el establecimiento para ese lugar + " Salida", y siendo el QR el id que guarda mongo para ese espacio + "_exit".

Si el parametro exitQR es false, genera un único QR:
1. Nombre dado por el establecimiento para ese lugar, y siendo el QR el id que guarda mongo para ese espacio

Adjunto una muestra de cada uno que generé desde la web app de react

@ct-fiuba/developers 

[QRs (17).pdf](https://github.com/ct-fiuba/visit-manager/files/5039354/QRs.17.pdf)
[QRs (16).pdf](https://github.com/ct-fiuba/visit-manager/files/5039355/QRs.16.pdf)
