### PR TITLE
Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
 language: node_js
+
 node_js:
   - "node"
+
 services:
   - docker
-sudo: required
 
-before_install:
-  - docker run --rm -d -p 27017:27017 --name="test" mongo:3.6.4
+sudo: required
 
 install:
   - npm install
+
+before_script:
+  - docker run --rm -d -p 27017:27017 --name="test" mongo:3.6.4
 
 script:
   - npm test && npm run test:integration


### PR DESCRIPTION
Agregue config de travis para que corra los tests usando la base en docker

Me parece que no hace falta agregar que corra los tests de la user api aca porque ya tenemos el e2e para eso.

@ct-fiuba/developers 