### PR TITLE
add n95, vaccines, and covid recovery variables

### DIFF
--- a/src/controllers/establishmentsController.js
+++ b/src/controllers/establishmentsController.js
@@ -1,4 +1,4 @@
-module.exports = function establishmentsController(establishmentHandler) {
+module.exports = function establishmentsController(establishmentHandler, spaceHandler) {
   const PDFGenerator = require('../services/PDFGenerator');
 
   const errorDB = (res, err) => {
@@ -17,7 +17,13 @@ module.exports = function establishmentsController(establishmentHandler) {
     return establishmentHandler.findEstablishment(req.params.establishmentId)
       .then(establishment => {
         if (!establishment) return res.status(404).json({ reason: 'Establishment not found' });
-        return res.status(200).json(establishment);
+        return spaceHandler.findSpaces({
+          '_id': { $in: establishment.spaces}
+        }).then(docs => {
+          let extendedEstablishment = JSON.parse(JSON.stringify(establishment));
+          extendedEstablishment["spacesInfo"] = docs;
+          res.status(200).json(extendedEstablishment);
+        }).catch(err => errorDB(res, err));
       })
       .catch(err => errorDB(res, err));
   };

--- a/src/middlewares/bodyVisitsValidatorMiddleware.js
+++ b/src/middlewares/bodyVisitsValidatorMiddleware.js
@@ -2,7 +2,7 @@ const { body , validationResult } = require('express-validator');
 
 module.exports = function bodyVisitsValidatorMiddleware() {
   const addValidations = [
-    body(['userGeneratedCode', 'scanCode', 'timestamp', 'vaccinated', 'covidRecovered'], 'Missing value').exists(),
+    body(['userGeneratedCode', 'scanCode', 'timestamp'], 'Missing value').exists(),
   ];
 
   const validate = (req, res, next) => {

--- a/src/middlewares/bodyVisitsValidatorMiddleware.js
+++ b/src/middlewares/bodyVisitsValidatorMiddleware.js
@@ -2,7 +2,7 @@ const { body , validationResult } = require('express-validator');
 
 module.exports = function bodyVisitsValidatorMiddleware() {
   const addValidations = [
-    body(['userGeneratedCode', 'scanCode', 'timestamp'], 'Missing value').exists(),
+    body(['userGeneratedCode', 'scanCode', 'timestamp', 'vaccinated', 'covidRecovered'], 'Missing value').exists(),
   ];
 
   const validate = (req, res, next) => {

--- a/src/models/handlers/EstablishmentHandler.js
+++ b/src/models/handlers/EstablishmentHandler.js
@@ -38,7 +38,8 @@ module.exports = function EstablishmentHandler() {
         estimatedVisitDuration: _space.estimatedVisitDuration,
         hasExit: _space.hasExit,
         openPlace: _space.openPlace,
-        establishmentId: establishmentData._id
+        establishmentId: establishmentData._id,
+        n95Mandatory: _space.n95Mandatory
       };
       SpaceIds.push(current_space._id);
       await SpaceHandler().addSpace(current_space);

--- a/src/models/handlers/VisitHandler.js
+++ b/src/models/handlers/VisitHandler.js
@@ -31,7 +31,12 @@ module.exports = function VisitHandler() {
       scanCode,
       isExitScan,
       userGeneratedCode: content.userGeneratedCode,
-      timestamp: content.timestamp
+      timestamp: content.timestamp,
+      vaccinated: content.vaccinated,
+      vaccineReceived: content.vaccineReceived,
+      vaccinatedDate: content.vaccinatedDate,
+      covidRecovered: content.covidRecovered,
+      covidRecoveredDate: content.covidRecoveredDate
     };
 
     let newVisit = new Visit(visitData);

--- a/src/models/schemas/Space.js
+++ b/src/models/schemas/Space.js
@@ -24,6 +24,10 @@ let spaceSchema = mongoose.Schema({
   establishmentId: {
     type: mongoose.Schema.Types.ObjectId,
     required: true
+  },
+  n95Mandatory: {
+    type: Boolean,
+    required: true
   }
 });
 

--- a/src/models/schemas/Space.js
+++ b/src/models/schemas/Space.js
@@ -27,6 +27,7 @@ let spaceSchema = mongoose.Schema({
   },
   n95Mandatory: {
     type: Boolean,
+    default: false,
     required: true
   }
 });

--- a/src/models/schemas/Visit.js
+++ b/src/models/schemas/Visit.js
@@ -22,6 +22,7 @@ let visitSchema = mongoose.Schema({
   },
   vaccinated: {
     type: Number,
+    default: 0,
     required: true
   },
   vaccineReceived: {
@@ -34,6 +35,7 @@ let visitSchema = mongoose.Schema({
   },
   covidRecovered: {
     type: Boolean,
+    default: false,
     required: true
   },
   covidRecoveredDate: {

--- a/src/models/schemas/Visit.js
+++ b/src/models/schemas/Visit.js
@@ -19,6 +19,26 @@ let visitSchema = mongoose.Schema({
     type: Date,
     default: Date.now(),
     required: true
+  },
+  vaccinated: {
+    type: Number,
+    required: true
+  },
+  vaccineReceived: {
+    type: String,
+    required: false
+  },
+  vaccinatedDate: {
+    type: Date,
+    required: false
+  },
+  covidRecovered: {
+    type: Boolean,
+    required: true
+  },
+  covidRecoveredDate: {
+    type: Date,
+    required: false
   }
 });
 

--- a/src/routes/establishmentsRouter.js
+++ b/src/routes/establishmentsRouter.js
@@ -2,7 +2,8 @@ const express = require('express');
 const bodyEstablishmentsValidator = require('../middlewares/bodyEstablishmentsValidatorMiddleware')();
 
 const establishmentHandler = require('../models/handlers/EstablishmentHandler');
-const establishmentsController = require('../controllers/establishmentsController')(establishmentHandler());
+const spaceHandler = require('../models/handlers/SpaceHandler');
+const establishmentsController = require('../controllers/establishmentsController')(establishmentHandler(), spaceHandler());
 
 module.exports = function establishmentsRouter() {
   return express.Router().use(

--- a/src/static/swagger.json
+++ b/src/static/swagger.json
@@ -361,6 +361,10 @@
                 "openSpace": {
                   "type": "boolean",
                   "example": "true"
+                },
+                "n95Mandatory": {
+                  "type": "boolean",
+                  "example": "false"
                 }
               }
             }
@@ -433,6 +437,10 @@
                 "openSpace": {
                   "type": "boolean",
                   "example": "true"
+                },
+                "n95Mandatory": {
+                  "type": "boolean",
+                  "example": "false"
                 }
               }
             }
@@ -509,7 +517,9 @@
           "scanCode",
           "userGeneratedCode",
           "timestamp",
-          "isExitScan"
+          "isExitScan",
+          "vaccinated",
+          "covidRecovered"
         ],
         "properties": {
           "scanCode": {
@@ -525,6 +535,26 @@
             "example": "1970-01-01 00:00:01"
           },
           "isExitScan": {
+            "type": "boolean",
+            "example": "true"
+          },
+          "vaccinated": {
+            "type": "integer",
+            "example": "1"
+          },
+          "vaccineReceived": {
+            "type": "string",
+            "example": "Pfizer"
+          },
+          "vaccinatedDate": {
+            "type": "datetime",
+            "example": "1970-01-01 00:00:01"
+          },
+          "covidRecovered": {
+            "type": "boolean",
+            "example": "true"
+          },
+          "covidRecoveredDate": {
             "type": "boolean",
             "example": "true"
           }

--- a/src/static/swagger.json
+++ b/src/static/swagger.json
@@ -358,7 +358,7 @@
                   "type": "integer",
                   "example": 200
                 },
-                "openSpace": {
+                "openPlace": {
                   "type": "boolean",
                   "example": "true"
                 },
@@ -434,7 +434,7 @@
                   "type": "integer",
                   "example": 200
                 },
-                "openSpace": {
+                "openPlace": {
                   "type": "boolean",
                   "example": "true"
                 },

--- a/test/integration/app.int.test.js
+++ b/test/integration/app.int.test.js
@@ -181,7 +181,9 @@ describe('App test', () => {
         const visit = {
           scanCode: spaces1_id[0],
           userGeneratedCode: "QWER1234YUIO",
-          timestamp: Date.now()
+          timestamp: Date.now(),
+          vaccinated: 0,
+          covidRecovered: false
         };
         await request(server).post('/visits').send(visit).then(res => {
           expect(res.status).toBe(201);
@@ -192,7 +194,9 @@ describe('App test', () => {
         const visit = {
           scanCode: spaces1_id[0],
           userGeneratedCode: "BNIUO1NT12NBF",
-          timestamp: Date.now()
+          timestamp: Date.now(),
+          vaccinated: 0,
+          covidRecovered: false
         };
         await request(server).post('/visits').send(visit).then(res => {
           expect(res.status).toBe(201);
@@ -203,7 +207,9 @@ describe('App test', () => {
         const visit = {
           scanCode: spaces1_id[0],
           userGeneratedCode: "QWER1234YUIO",
-          timestamp: Date.now()
+          timestamp: Date.now(),
+          vaccinated: 0,
+          covidRecovered: false
         };
         await request(server).post('/visits').send(visit).then(res => {
           expect(res.status).toBe(409);
@@ -214,7 +220,9 @@ describe('App test', () => {
         const visit = {
           scanCode: spaces1_id[1],
           userGeneratedCode: "QWER1234YUIO",
-          timestamp: Date.now()
+          timestamp: Date.now(),
+          vaccinated: 0,
+          covidRecovered: false
         };
         await request(server).post('/visits').send(visit).then(res => {
           expect(res.status).toBe(409);
@@ -241,7 +249,9 @@ describe('App test', () => {
         const visit = {
           scanCode: new mongoose.Types.ObjectId(),
           userGeneratedCode: "XCBVQIWERU1234",
-          timestamp: Date.now()
+          timestamp: Date.now(),
+          vaccinated: 0,
+          covidRecovered: false
         };
         await request(server).post('/visits').send(visit).then(res => {
           expect(res.status).toBe(404);
@@ -252,7 +262,9 @@ describe('App test', () => {
         const visit = {
           scanCode: `${spaces1_id[1]}_exit`,
           userGeneratedCode: "POIQULNVOER",
-          timestamp: Date.now()
+          timestamp: Date.now(),
+          vaccinated: 0,
+          covidRecovered: false
         };
         await request(server).post('/visits').send(visit).then(res => {
           expect(res.status).toBe(201);

--- a/test/integration/app.int.test.js
+++ b/test/integration/app.int.test.js
@@ -20,14 +20,16 @@ let spaces1 = [
       hasExit: true,
       m2: "1000",
       estimatedVisitDuration: "60",
-      openPlace: false
+      openPlace: false,
+      n95Mandatory: false
     },
     {
       name: "Terraza",
       hasExit: false,
       m2: "400",
       estimatedVisitDuration: "45",
-      openPlace: true
+      openPlace: true,
+      n95Mandatory: false
     }
   ];
 
@@ -41,7 +43,8 @@ let spaces2 = [
       hasExit: false,
       m2: "3000",
       estimatedVisitDuration: "30",
-      openPlace: false
+      openPlace: false,
+      n95Mandatory: false
     }
   ];
 

--- a/test/unit/establishmentsController.unit.test.js
+++ b/test/unit/establishmentsController.unit.test.js
@@ -104,7 +104,7 @@ describe('getSingleEstablishment', () => {
       await establishmentsController.getSingleEstablishment(req, res, next);
       expect(establishmentHandler.findEstablishment).toHaveBeenCalledWith(_id);
       expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith(exampleEstablishment);
+      expect(res.json).toHaveBeenCalledWith({...exampleEstablishment, spacesInfo});
     });
   });
 

--- a/test/unit/establishmentsController.unit.test.js
+++ b/test/unit/establishmentsController.unit.test.js
@@ -14,6 +14,28 @@ let state = 'CABA';
 let zip = '1430ACV';
 let country = 'Argentina';
 let spaces = ['ASDF1234', 'QWER4563'];
+let spacesInfo = [
+  {
+    _id: "ASDF1234",
+    name: "id qr 1",
+    m2: 10,
+    estimatedVisitDuration: 30,
+    hasExit: false,
+    openPlace: true,
+    establishmentId: _id,
+    n95Mandatory: true
+  },
+  {
+    _id: "QWER4563",
+    name: "id qr 2",
+    m2: 20,
+    estimatedVisitDuration: 40,
+    hasExit: false,
+    openPlace: true,
+    establishmentId: _id,
+    n95Mandatory: true
+  }
+];
 
 beforeEach(() => {
   establishmentHandler = {
@@ -24,7 +46,10 @@ beforeEach(() => {
     updateEstablishment: jest.fn(),
     deleteEstablishment: jest.fn()
   };
-  establishmentsController = establishmentsControllerFactory(establishmentHandler);
+  spaceHandler = {
+    findSpaces: jest.fn()
+  };
+  establishmentsController = establishmentsControllerFactory(establishmentHandler, spaceHandler);
   req = {
     body: {},
     params: {},
@@ -72,6 +97,7 @@ describe('getSingleEstablishment', () => {
     beforeEach(() => {
       req.params = { establishmentId: _id };
       establishmentHandler.findEstablishment.mockResolvedValue(exampleEstablishment);
+      spaceHandler.findSpaces.mockResolvedValue(spacesInfo);
     });
 
     test('should respond successfully', async () => {
@@ -86,6 +112,7 @@ describe('getSingleEstablishment', () => {
     beforeEach(() => {
       req.params = { establishmentId: _id };
       establishmentHandler.findEstablishment.mockResolvedValue(null);
+      spaceHandler.findSpaces.mockResolvedValue(spacesInfo);
     });
 
     test('should respond successfully', async () => {

--- a/test/unit/visitsController.unit.test.js
+++ b/test/unit/visitsController.unit.test.js
@@ -63,7 +63,8 @@ describe('add', () => {
         hasExit: true,
         m2: "1000",
         estimatedVisitDuration: "60",
-        openPlace: false
+        openPlace: false,
+        n95Mandatory: false
       });
       visitHandler.addVisit.mockResolvedValue(exampleVisit);
     });


### PR DESCRIPTION
- Updateo schemas y tests
- Hago que la llamada get para obtener info sobre un solo establishment devuelva el detalle de todos sus espacios. Esto sirve para probar que se guarde bien el parametro de N95 a nivel de espacio, y si en un futuro hacemos una cuenta a nivel establecimiento es mas facil mostrar la info de todos los espacios