### PR TITLE
Add exit timestamp to visit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.DS_Store
 *coverage
 .env
+package-lock.json

--- a/src/controllers/visitsController.js
+++ b/src/controllers/visitsController.js
@@ -17,8 +17,13 @@ module.exports = function visitsController(visitHandler) {
     return await visitsService(visitHandler).registerVisit(req, res);
   };
 
+  const addExitTimestamp = async (req, res, next) => {
+    return await visitsService(visitHandler).addExitTimestamp(req, res);
+  };
+
   return {
     add,
+    addExitTimestamp,
     get
   };
 };

--- a/src/middlewares/bodyVisitsValidatorMiddleware.js
+++ b/src/middlewares/bodyVisitsValidatorMiddleware.js
@@ -5,6 +5,10 @@ module.exports = function bodyVisitsValidatorMiddleware() {
     body(['userGeneratedCode', 'scanCode', 'entranceTimestamp'], 'Missing value').exists(),
   ];
 
+  const addExitTimestampValidations = [
+    body(['userGeneratedCode', 'scanCode', 'exitTimestamp'], 'Missing value').exists(),
+  ];
+
   const validate = (req, res, next) => {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {
@@ -17,6 +21,7 @@ module.exports = function bodyVisitsValidatorMiddleware() {
 
   return {
     addValidations,
+    addExitTimestampValidations,
     validate
   };
 };

--- a/src/middlewares/bodyVisitsValidatorMiddleware.js
+++ b/src/middlewares/bodyVisitsValidatorMiddleware.js
@@ -2,7 +2,7 @@ const { body , validationResult } = require('express-validator');
 
 module.exports = function bodyVisitsValidatorMiddleware() {
   const addValidations = [
-    body(['userGeneratedCode', 'scanCode', 'timestamp'], 'Missing value').exists(),
+    body(['userGeneratedCode', 'scanCode', 'entranceTimestamp'], 'Missing value').exists(),
   ];
 
   const validate = (req, res, next) => {

--- a/src/models/handlers/VisitHandler.js
+++ b/src/models/handlers/VisitHandler.js
@@ -1,4 +1,5 @@
 const Visit = require('../schemas/Visit');
+const Space = require('../schemas/Space');
 const mongoose = require('mongoose');
 const SpaceHandler = require('./SpaceHandler');
 

--- a/src/models/handlers/VisitHandler.js
+++ b/src/models/handlers/VisitHandler.js
@@ -21,9 +21,6 @@ module.exports = function VisitHandler() {
 
   const addVisit = async (content) => {
     let scanCode = content.scanCode;
-    if (scanCode.substr(scanCode.length - 5) === '_exit') {
-      scanCode = scanCode.substr(0, scanCode.length - 5);
-    }
     let visitData = {
       _id: new mongoose.Types.ObjectId(),
       scanCode,
@@ -40,10 +37,38 @@ module.exports = function VisitHandler() {
     return newVisit.save();
   };
 
+  const addExitTimestamp = async (content) => {
+    let visit = await Visit.findOne({ userGeneratedCode: content.userGeneratedCode });
+    if (visit) {
+      // visit exists, happy path
+      return await Visit.updateOne({ _id: visit._id }, { exitTimestamp: content.exitTimestamp });
+    } else {
+      // entrance scan not found
+      let space = await Space.findOne({ _id: content.scanCode });
+      let entranceTimestamp = new Date(content.exitTimestamp);
+      entranceTimestamp.setMinutes(entranceTimestamp.getMinutes() - space.estimatedVisitDuration);
+      let visitData = {
+        _id: new mongoose.Types.ObjectId(),
+        scanCode: content.scanCode,
+        userGeneratedCode: content.userGeneratedCode,
+        entranceTimestamp,
+        exitTimestamp: content.exitTimestamp,
+        vaccinated: content.vaccinated,
+        vaccineReceived: content.vaccineReceived,
+        vaccinatedDate: content.vaccinatedDate,
+        covidRecovered: content.covidRecovered,
+        covidRecoveredDate: content.covidRecoveredDate
+      };
+      let newVisit = new Visit(visitData);
+      return newVisit.save();
+    }
+  };
+
   return {
     findVisits,
     visitExists,
     spaceExists,
-    addVisit
+    addVisit,
+    addExitTimestamp
   };
 };

--- a/src/models/handlers/VisitHandler.js
+++ b/src/models/handlers/VisitHandler.js
@@ -28,7 +28,7 @@ module.exports = function VisitHandler() {
       _id: new mongoose.Types.ObjectId(),
       scanCode,
       userGeneratedCode: content.userGeneratedCode,
-      timestamp: content.timestamp,
+      entranceTimestamp: content.entranceTimestamp,
       vaccinated: content.vaccinated,
       vaccineReceived: content.vaccineReceived,
       vaccinatedDate: content.vaccinatedDate,

--- a/src/models/handlers/VisitHandler.js
+++ b/src/models/handlers/VisitHandler.js
@@ -21,15 +21,12 @@ module.exports = function VisitHandler() {
 
   const addVisit = async (content) => {
     let scanCode = content.scanCode;
-    let isExitScan = false;
     if (scanCode.substr(scanCode.length - 5) === '_exit') {
       scanCode = scanCode.substr(0, scanCode.length - 5);
-      isExitScan = true;
     }
     let visitData = {
       _id: new mongoose.Types.ObjectId(),
       scanCode,
-      isExitScan,
       userGeneratedCode: content.userGeneratedCode,
       timestamp: content.timestamp,
       vaccinated: content.vaccinated,

--- a/src/models/schemas/Visit.js
+++ b/src/models/schemas/Visit.js
@@ -5,11 +5,6 @@ let visitSchema = mongoose.Schema({
     type: mongoose.Schema.Types.ObjectId,
     required: true
   },
-  isExitScan: {
-    type: Boolean,
-    default: false,
-    required: true
-  },
   userGeneratedCode: {
     type: String,
     required: true,

--- a/src/models/schemas/Visit.js
+++ b/src/models/schemas/Visit.js
@@ -10,10 +10,14 @@ let visitSchema = mongoose.Schema({
     required: true,
     unique: true
   },
-  timestamp: {
+  entranceTimestamp: {
     type: Date,
     default: Date.now(),
     required: true
+  },
+  exitTimestamp: {
+    type: Date,
+    required: false
   },
   vaccinated: {
     type: Number,

--- a/src/routes/visitsRouter.js
+++ b/src/routes/visitsRouter.js
@@ -10,5 +10,6 @@ module.exports = function visitsRouter() {
     express.Router()
       .get('/', visitsController.get)
       .post('/', bodyVisitsValidator.addValidations, bodyVisitsValidator.validate, visitsController.add)
+      .post('/addExitTimestamp', bodyVisitsValidator.addExitTimestampValidations, bodyVisitsValidator.validate, visitsController.addExitTimestamp)
   );
 };

--- a/src/services/visitsService.js
+++ b/src/services/visitsService.js
@@ -27,7 +27,24 @@ module.exports = function visitsService(visitHandler) {
       .catch(err => errorDB(res, err));
   };
 
+  const addExitTimestamp = async (req, res) => {
+    return visitHandler.spaceExists(req.body.scanCode)
+      .then(space => {
+        if (!space) {
+          return res.status(404).json({ reason: 'Space linked to the scan code not found' });
+        }
+        if (!space.enabled) {
+          return res.status(404).json({ reason: 'Space linked to the scan code is disabled' });
+        }
+        return visitHandler.addExitTimestamp(req.body)
+          .then(visit => res.status(201).json({ _id: visit._id, exitTimestamp: visit.exitTimestamp }))
+          .catch(err => errorDB(res, err));
+      })
+      .catch(err => errorDB(res, err));
+  };
+
   return {
-    registerVisit
+    registerVisit,
+    addExitTimestamp
   };
 };

--- a/src/static/swagger.json
+++ b/src/static/swagger.json
@@ -697,7 +697,7 @@
         "required": [
           "scanCode",
           "userGeneratedCode",
-          "timestamp",
+          "entranceTimestamp",
           "genuxToken"
         ],
         "properties": {
@@ -709,7 +709,7 @@
             "type": "string",
             "example": "1PWIOEJPOVUP12OI34J"
           },
-          "timestamp": {
+          "entranceTimestamp": {
             "type": "string",
             "example": "1970-01-01 00:00:01"
           },
@@ -843,7 +843,7 @@
         "required": [
           "scanCode",
           "userGeneratedCode",
-          "timestamp",
+          "entranceTimestamp",
           "vaccinated",
           "covidRecovered"
         ],
@@ -856,7 +856,7 @@
             "type": "string",
             "example": "1PWIOEJPOVUP12OI34J"
           },
-          "timestamp": {
+          "entranceTimestamp": {
             "type": "string",
             "example": "1970-01-01 00:00:01"
           },

--- a/src/static/swagger.json
+++ b/src/static/swagger.json
@@ -475,36 +475,89 @@
           }
         }
       }
+    },
+    "/visits/addExitTimestamp": {
+      "post": {
+        "tags": [
+          "visits"
+        ],
+        "summary": "Add exit timestamp to visit",
+        "operationId": "addExitTimestamp",
+        "requestBody": {
+          "description": "Add exit timestamp to visit",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/VisitAddExitTimestamp"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Visit updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "_id": {
+                      "type": "string",
+                      "example": "1"
+                    },
+                    "exitTimestamp": {
+                      "type": "string",
+                      "example": "1970-01-01 00:00:01"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing fields / Invalid visibility"
+          },
+          "404": {
+            "description": "Space linked to the scan code not found"
+          }
+        }
+      }
     }
   },
   "components": {
     "parameters": {
-        "pathEstablishmentId": {
-          "in": "path",
-          "name": "establishmentId",
-          "required": true,
-          "schema": {
-            "type": "integer",
-            "minimum": 1
-          }
-        },
-        "pathSpaceId": {
-          "in": "path",
-          "name": "spaceId",
-          "required": true,
-          "schema": {
-            "type": "integer",
-            "minimum": 1
-          }
-        },
-        "pathOwnerId": {
-          "in": "path",
-          "name": "ownerId",
-          "required": true,
-          "schema": {
-            "type": "string"
-          }
+      "pathEstablishmentId": {
+        "in": "path",
+        "name": "establishmentId",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
         }
+      },
+      "pathSpaceId": {
+        "in": "path",
+        "name": "spaceId",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "pathOwnerId": {
+        "in": "path",
+        "name": "ownerId",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      }
     },
     "schemas": {
       "Establishment": {
@@ -857,6 +910,50 @@
             "example": "1PWIOEJPOVUP12OI34J"
           },
           "entranceTimestamp": {
+            "type": "string",
+            "example": "1970-01-01 00:00:01"
+          },
+          "vaccinated": {
+            "type": "integer",
+            "example": "1"
+          },
+          "vaccineReceived": {
+            "type": "string",
+            "example": "Pfizer"
+          },
+          "vaccinatedDate": {
+            "type": "string",
+            "example": "1970-01-01 00:00:01"
+          },
+          "covidRecovered": {
+            "type": "boolean",
+            "example": "true"
+          },
+          "covidRecoveredDate": {
+            "type": "boolean",
+            "example": "true"
+          }
+        }
+      },
+      "VisitAddExitTimestamp": {
+        "type": "object",
+        "required": [
+          "scanCode",
+          "userGeneratedCode",
+          "exitTimestamp",
+          "vaccinated",
+          "covidRecovered"
+        ],
+        "properties": {
+          "scanCode": {
+            "type": "string",
+            "example": "MNPQWOEUPO452345"
+          },
+          "userGeneratedCode": {
+            "type": "string",
+            "example": "1PWIOEJPOVUP12OI34J"
+          },
+          "exitTimestamp": {
             "type": "string",
             "example": "1970-01-01 00:00:01"
           },

--- a/src/static/swagger.json
+++ b/src/static/swagger.json
@@ -95,7 +95,7 @@
           }
         }
       }
-    }, 
+    },
     "/establishments/space": {
       "post": {
         "tags": [
@@ -844,7 +844,6 @@
           "scanCode",
           "userGeneratedCode",
           "timestamp",
-          "isExitScan",
           "vaccinated",
           "covidRecovered"
         ],
@@ -860,10 +859,6 @@
           "timestamp": {
             "type": "string",
             "example": "1970-01-01 00:00:01"
-          },
-          "isExitScan": {
-            "type": "boolean",
-            "example": "true"
           },
           "vaccinated": {
             "type": "integer",

--- a/test/integration/app.int.test.js
+++ b/test/integration/app.int.test.js
@@ -377,14 +377,6 @@ describe('App test', () => {
         });
       });
 
-      test('get visits to the second space should return 1 scan with isExitScan set to true', async () => {
-        await request(server).get(`/visits?scanCode=${spaces1_id[1]}`).then(res => {
-          expect(res.status).toBe(200);
-          expect(res.body.length).toBe(1);
-          expect(res.body[0].isExitScan).toBeTruthy();
-        });
-      });
-
       test('add visit to disabled space should return 404', async () => {
         const spaceUpdateBody = {
           establishmentId: establishment_id1,

--- a/test/integration/app.int.test.js
+++ b/test/integration/app.int.test.js
@@ -29,6 +29,14 @@ let spaces1 = [
       estimatedVisitDuration: "45",
       openPlace: true,
       n95Mandatory: false
+    },
+    {
+      name: "Subsuelo",
+      hasExit: true,
+      m2: "40",
+      estimatedVisitDuration: "10",
+      openPlace: false,
+      n95Mandatory: false
     }
   ];
 
@@ -213,7 +221,7 @@ describe('App test', () => {
       test('disabled space should return enabled: false', async () => {
         await request(server).get(`/establishments/${establishment_id1}`).then(res => {
           expect(res.status).toBe(200);
-          expect(res.body.spacesInfo.map(x => x.enabled ? 1 : 0).reduce((a, b) => a+b)).toBe(1);
+          expect(res.body.spacesInfo.map(x => x.enabled ? 1 : 0).reduce((a, b) => a+b)).toBe(2);
         });
       });
 
@@ -250,7 +258,7 @@ describe('App test', () => {
       test('enabled previously disabled space should return enabled: true', async () => {
         await request(server).get(`/establishments/${establishment_id1}`).then(res => {
           expect(res.status).toBe(200);
-          expect(res.body.spacesInfo.map(x => x.enabled ? 1 : 0).reduce((a, b) => a+b)).toBe(2);
+          expect(res.body.spacesInfo.map(x => x.enabled ? 1 : 0).reduce((a, b) => a+b)).toBe(3);
         });
       });
     });
@@ -405,6 +413,37 @@ describe('App test', () => {
           expect(res.body.length).toBe(1);
           expect(res.body[0].userGeneratedCode).toBe("YUIOPHJK1234YUIO");
           expect(res.body[0]).toHaveProperty('exitTimestamp')
+        });
+      });
+
+      test('update visit with exit timestamp when the visit does not exist should also return 201', async () => {
+        const visit = {
+          scanCode: spaces1_id[2],
+          userGeneratedCode: "YUIOPHJK1234YUIO1234",
+          exitTimestamp: Date.now(),
+          vaccinated: 0,
+          covidRecovered: false
+        };
+        await request(server).post('/visits/addExitTimestamp').send(visit).then(res => {
+          expect(res.status).toBe(201);
+        });
+      });
+
+      test('get visits to the third space should return 1 scan with exitTimestamp', async () => {
+        await request(server).get(`/visits?scanCode=${spaces1_id[2]}`).then(res => {
+          expect(res.status).toBe(200);
+          expect(res.body.length).toBe(1);
+          expect(res.body[0].userGeneratedCode).toBe("YUIOPHJK1234YUIO1234");
+          expect(res.body[0]).toHaveProperty('exitTimestamp')
+        });
+      });
+
+      test('get visits to the second space should a visit with the entranceTimestamp equal to the exitTimestamp minus the estimatedVisitDuration of the space', async () => {
+        await request(server).get(`/visits?scanCode=${spaces1_id[2]}`).then(res => {
+          expect(res.status).toBe(200);
+          let entranceTimestamp = new Date(res.body[0].exitTimestamp);
+          entranceTimestamp.setMinutes(entranceTimestamp.getMinutes() - 10);
+          expect((new Date(res.body[0].entranceTimestamp)).toString()).toBe(entranceTimestamp.toString());
         });
       });
 

--- a/test/integration/app.int.test.js
+++ b/test/integration/app.int.test.js
@@ -287,7 +287,7 @@ describe('App test', () => {
         const visit = {
           scanCode: spaces1_id[0],
           userGeneratedCode: "QWER1234YUIO",
-          timestamp: Date.now(),
+          entranceTimestamp: Date.now(),
           vaccinated: 0,
           covidRecovered: false
         };
@@ -300,7 +300,7 @@ describe('App test', () => {
         const visit = {
           scanCode: spaces1_id[0],
           userGeneratedCode: "BNIUO1NT12NBF",
-          timestamp: Date.now(),
+          entranceTimestamp: Date.now(),
           vaccinated: 0,
           covidRecovered: false
         };
@@ -313,7 +313,7 @@ describe('App test', () => {
         const visit = {
           scanCode: spaces1_id[0],
           userGeneratedCode: "QWER1234YUIO",
-          timestamp: Date.now(),
+          entranceTimestamp: Date.now(),
           vaccinated: 0,
           covidRecovered: false
         };
@@ -326,7 +326,7 @@ describe('App test', () => {
         const visit = {
           scanCode: spaces1_id[1],
           userGeneratedCode: "QWER1234YUIO",
-          timestamp: Date.now(),
+          entranceTimestamp: Date.now(),
           vaccinated: 0,
           covidRecovered: false
         };
@@ -355,7 +355,7 @@ describe('App test', () => {
         const visit = {
           scanCode: new mongoose.Types.ObjectId(),
           userGeneratedCode: "XCBVQIWERU1234",
-          timestamp: Date.now(),
+          entranceTimestamp: Date.now(),
           vaccinated: 0,
           covidRecovered: false
         };
@@ -368,7 +368,7 @@ describe('App test', () => {
         const visit = {
           scanCode: `${spaces1_id[1]}_exit`,
           userGeneratedCode: "POIQULNVOER",
-          timestamp: Date.now(),
+          entranceTimestamp: Date.now(),
           vaccinated: 0,
           covidRecovered: false
         };
@@ -386,7 +386,7 @@ describe('App test', () => {
         const visit = {
           scanCode: `${spaces1_id[0]}`,
           userGeneratedCode: "POIQULNVOZZ",
-          timestamp: Date.now(),
+          entranceTimestamp: Date.now(),
           vaccinated: 0,
           covidRecovered: false
         };

--- a/test/integration/app.int.test.js
+++ b/test/integration/app.int.test.js
@@ -364,16 +364,47 @@ describe('App test', () => {
         });
       });
 
-      test('add visit to the second space with _exit suffix should return 201', async () => {
+      test('add first visit to the second space should return 201', async () => {
         const visit = {
-          scanCode: `${spaces1_id[1]}_exit`,
-          userGeneratedCode: "POIQULNVOER",
+          scanCode: spaces1_id[1],
+          userGeneratedCode: "YUIOPHJK1234YUIO",
           entranceTimestamp: Date.now(),
           vaccinated: 0,
           covidRecovered: false
         };
         await request(server).post('/visits').send(visit).then(res => {
           expect(res.status).toBe(201);
+        });
+      });
+
+      test('get visits to the second space should return 1 scan without exitTimestamp', async () => {
+        await request(server).get(`/visits?scanCode=${spaces1_id[1]}`).then(res => {
+          expect(res.status).toBe(200);
+          expect(res.body.length).toBe(1);
+          expect(res.body[0].userGeneratedCode).toBe("YUIOPHJK1234YUIO");
+          expect(res.body[0]).not.toHaveProperty('exitTimestamp')
+        });
+      });
+
+      test('update visit with exit timestamp should return 201', async () => {
+        const visit = {
+          scanCode: spaces1_id[1],
+          userGeneratedCode: "YUIOPHJK1234YUIO",
+          exitTimestamp: Date.now(),
+          vaccinated: 0,
+          covidRecovered: false
+        };
+        await request(server).post('/visits/addExitTimestamp').send(visit).then(res => {
+          expect(res.status).toBe(201);
+        });
+      });
+
+      test('get visits to the second space should return 1 scan with exitTimestamp', async () => {
+        await request(server).get(`/visits?scanCode=${spaces1_id[1]}`).then(res => {
+          expect(res.status).toBe(200);
+          expect(res.body.length).toBe(1);
+          expect(res.body[0].userGeneratedCode).toBe("YUIOPHJK1234YUIO");
+          expect(res.body[0]).toHaveProperty('exitTimestamp')
         });
       });
 

--- a/test/unit/PDFGenerator.unit.test.js
+++ b/test/unit/PDFGenerator.unit.test.js
@@ -28,7 +28,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   if (await existsPromise(testFilesDirectory)) {
-    await new Promise(r => setTimeout(r, 1000));
+    await new Promise(r => setTimeout(r, 3000));
     await rmdirPromise(testFilesDirectory);
   }
 });
@@ -39,6 +39,7 @@ describe('PDF generator', () => {
     let file_exists = await existsPromise(pathQR);
     expect(file_exists).toBeTruthy();
     await PDFGenerator().deleteFile(pathQR);
+    await new Promise(r => setTimeout(r, 2000));
     file_exists = await existsPromise(pathQR);
     expect(file_exists).toBeFalsy();
   });
@@ -49,6 +50,7 @@ describe('PDF generator', () => {
     let file_exists = await existsPromise(pathPDF);
     expect(file_exists).toBeTruthy();
     await PDFGenerator().deleteFile(pathPDF);
+    await new Promise(r => setTimeout(r, 2000));
     file_exists = await existsPromise(pathPDF);
     expect(file_exists).toBeFalsy();
   });

--- a/test/unit/PDFGenerator.unit.test.js
+++ b/test/unit/PDFGenerator.unit.test.js
@@ -28,7 +28,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   if (await existsPromise(testFilesDirectory)) {
-    await new Promise(r => setTimeout(r, 3000));
+    await new Promise(r => setTimeout(r, 1000));
     await rmdirPromise(testFilesDirectory);
   }
 });
@@ -39,7 +39,6 @@ describe('PDF generator', () => {
     let file_exists = await existsPromise(pathQR);
     expect(file_exists).toBeTruthy();
     await PDFGenerator().deleteFile(pathQR);
-    await new Promise(r => setTimeout(r, 2000));
     file_exists = await existsPromise(pathQR);
     expect(file_exists).toBeFalsy();
   });
@@ -50,7 +49,6 @@ describe('PDF generator', () => {
     let file_exists = await existsPromise(pathPDF);
     expect(file_exists).toBeTruthy();
     await PDFGenerator().deleteFile(pathPDF);
-    await new Promise(r => setTimeout(r, 2000));
     file_exists = await existsPromise(pathPDF);
     expect(file_exists).toBeFalsy();
   });

--- a/test/unit/visitsController.unit.test.js
+++ b/test/unit/visitsController.unit.test.js
@@ -7,7 +7,7 @@ let next;
 let _id = 1;
 let scanCode = 'ASDF1234';
 let userGeneratedCode = 'QWER456309852';
-let timestamp = Date.now();
+let entranceTimestamp = Date.now();
 
 beforeEach(() => {
   visitHandler = {
@@ -34,7 +34,7 @@ const exampleVisit = {
   _id,
   scanCode,
   userGeneratedCode,
-  timestamp,
+  entranceTimestamp,
 };
 
 describe('get', () => {


### PR DESCRIPTION
Antes cuando la app escaneaba un QR de salida se creaba una nueva visita con el campo `isExitScan` en true. Ahora agregamos un nuevo endpoint para updatear una visita existente y agregarle el exitTimestamp.

Cambios:
- Se saco el campo isExitScan
- Se cambio el nombre del campo timestamp por entranceTimestamp
- Se agrego el campo exitTimestamp, que puede ser nullable. Cuando se crea una nueva visita, este campo no existe. Si una visita no tiene exitTimestamp quiere decir que no se marco la salida por el momento, por lo que se deberia tomar el space.estimatedVisitDuration + visit.entranceTimestamp como duracion de la visita.
- Se agrega un endpoint para el update del campo exitTimestamp. En este endpoint se espera recibir un userGeneratedCode de una visita existente (la de entrada), para poder encontrar esa visita y updatear el exitTimestamp al valor recibido.
- En el caso de que la visita no exista (puede ser error de nuestro lado, de conectividad o que el usuario no haya escaneado el QR de entrada), este nuevo endpoint crea una nueva visita con el exitTimestamp recibido y como entranceTimestamp se toma el visit.exitTimestamp - space.estimatedVisitDuration.
- Update de los tests