### PR TITLE
Change base image to reduce significantly the image size

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,4 +1,4 @@
-FROM node:12.4.0
+FROM node:12-alpine3.13
 
 WORKDIR /app 
 


### PR DESCRIPTION
Generic node image:
```
$ docker images | grep visit-manager
ct-visit-manager   latest   082e2417f06b   4 days ago   1.09GB
```

Using alpine based image:
```
$ docker images | grep visit-manager
ct-visit-manager   latest   86af6d04e210   48 seconds ago   273MB
```